### PR TITLE
div estilado como botón

### DIFF
--- a/client/main.css
+++ b/client/main.css
@@ -143,6 +143,9 @@ a:hover {
 	font-weight: 500;
 }
 
+/*
+div estilado como botón
+*/
 .latest_tweets {
 	background-color: #1777a0;
 	color: white;


### PR DESCRIPTION
El estilo de este div es muy parecido al de un botón, en especial cuando aún no han aparecido los tweets. Por lo menos yo estaba esperando que al hacer click se iban a mostrar los tweets. Les recomendaría revisar en la herramienta de analytics si los usuarios usualmente creen que se trata de un botón.