### PR TITLE
Ajustar las escalas del Bar Chart

### DIFF
--- a/imports/charts/BarChart.js
+++ b/imports/charts/BarChart.js
@@ -42,6 +42,7 @@ export function barChart(type_graph){
 				.attr('height', height)
 				.attr('class', 'bars');
 
+			// ajustar las escalas
 			var bar = bars.selectAll('.movie')
 				.data(data)
 				.enter().append('g')


### PR DESCRIPTION
Al cargar la página en donde está el Bar Chart las barras más grandes aparecen cortadas. Esto se podría corregir haciendo que el componente que contiene el svg sea responsive. El otro problema que vi es que el eje de la gráfica no se ve, y toca hacer zoom out en el navegador para verlo. Podría solucionarse poniendo el eje encima de las barras.